### PR TITLE
Fix footer navigation visibility across breakpoints

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -190,17 +190,25 @@ footer a {
   color: var(--muted);
 }
 
+footer nav ul {
+  display: flex;
+  justify-content: center;
+}
+
 nav ul {
   list-style: none;
   margin: 0;
   padding: 0;
-  display: none;
   flex-wrap: wrap;
   gap: 1.5rem;
   align-items: center;
 }
 
-nav ul.is-open {
+.header nav ul {
+  display: none;
+}
+
+.header nav ul.is-open {
   display: flex;
 }
 
@@ -276,7 +284,7 @@ p {
     gap: 1rem;
   }
 
-  nav ul {
+  .header nav ul {
     width: 100%;
     flex-direction: column;
     justify-content: center;
@@ -288,7 +296,7 @@ p {
 }
 
 @media (min-width: 768px) {
-  nav ul {
+  .header nav ul {
     display: flex !important;
   }
 


### PR DESCRIPTION
## Summary
- scope the mobile toggle styles to the header navigation so other lists remain visible
- add footer-specific flex styling to keep the links centered without the header toggle class
- update responsive rules to only target the header navigation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e58cf458c48331a0fec2df4c8da7ce