### PR TITLE
Add Wilson branding across navigation and key sections

### DIFF
--- a/app/about-us/page.tsx
+++ b/app/about-us/page.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from "next";
 import { CallToActionBanner } from "@/components/CallToActionBanner";
+import { BrandLogo } from "@/components/BrandLogo";
 
 export const metadata: Metadata = {
   title: "About Wilson Moving and Property Services",
@@ -30,6 +31,7 @@ export default function AboutPage() {
     <>
       <section className="hero">
         <div className="container">
+          <BrandLogo className="hero-logo" />
           <h1>Local movers with a reputation for excellence.</h1>
           <p>
             Founded in East Austin, Wilson Moving and Property Services grew from a single

--- a/app/customer-reviews/page.tsx
+++ b/app/customer-reviews/page.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from "next";
 import { CallToActionBanner } from "@/components/CallToActionBanner";
+import { BrandLogo } from "@/components/BrandLogo";
 
 export const metadata: Metadata = {
   title: "Customer Reviews",
@@ -40,6 +41,7 @@ export default function CustomerReviewsPage() {
     <>
       <section className="hero">
         <div className="container">
+          <BrandLogo className="hero-logo" />
           <h1>What our clients say.</h1>
           <p>
             Our reputation is built on dependable service and attentive crews. Here’s how

--- a/app/free-moving-quote/page.tsx
+++ b/app/free-moving-quote/page.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from "next";
+import { BrandLogo } from "@/components/BrandLogo";
 
 export const metadata: Metadata = {
   title: "Free Moving Quote",
@@ -10,6 +11,7 @@ export default function FreeMovingQuotePage() {
   return (
     <section className="hero">
       <div className="container">
+        <BrandLogo className="hero-logo" />
         <h1>Request your free moving quote.</h1>
         <p>
           Share the details of your upcoming move and our coordinators will reach out within

--- a/app/globals.css
+++ b/app/globals.css
@@ -194,13 +194,19 @@ nav ul {
   list-style: none;
   margin: 0;
   padding: 0;
-  display: none;
+  display: flex;
   flex-wrap: wrap;
   gap: 1.5rem;
   align-items: center;
 }
 
-nav ul.is-open {
+.header nav ul {
+  display: none;
+  flex-direction: column;
+  width: 100%;
+}
+
+.header nav ul.is-open {
   display: flex;
 }
 
@@ -337,9 +343,7 @@ p {
     gap: 1rem;
   }
 
-  nav ul {
-    width: 100%;
-    flex-direction: column;
+  .header nav ul {
     justify-content: center;
   }
 
@@ -349,8 +353,10 @@ p {
 }
 
 @media (min-width: 768px) {
-  nav ul {
+  .header nav ul {
     display: flex !important;
+    flex-direction: row;
+    width: auto;
   }
 
   .nav-toggle {

--- a/app/globals.css
+++ b/app/globals.css
@@ -250,11 +250,72 @@ nav a:hover {
 }
 
 .logo {
-  font-size: 1.1rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.95rem;
   font-weight: 700;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
   color: var(--accent-strong);
+  line-height: 1;
+}
+
+.logo-mark {
+  display: inline-flex;
+  padding: 0.35rem;
+  border-radius: 14px;
+  background: rgba(248, 245, 239, 0.08);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.45);
+}
+
+.logo-mark span,
+.logo-mark img {
+  display: block;
+}
+
+.logo-text {
+  letter-spacing: 0.18em;
+  font-size: 0.95rem;
+}
+
+.hero-logo {
+  display: inline-flex;
+  padding: 0.5rem;
+  border-radius: 20px;
+  background: rgba(248, 245, 239, 0.05);
+  box-shadow: 0 20px 45px rgba(0, 0, 0, 0.45);
+  margin-bottom: 1.75rem;
+}
+
+.hero-logo img {
+  display: block;
+}
+
+.footer-logo {
+  display: inline-flex;
+  padding: 0.35rem;
+  border-radius: 16px;
+  background: rgba(248, 245, 239, 0.04);
+  box-shadow: 0 15px 35px rgba(0, 0, 0, 0.45);
+  margin-bottom: 1.5rem;
+}
+
+.footer-logo img {
+  display: block;
+}
+
+.cta-logo {
+  display: inline-flex;
+  padding: 0.4rem;
+  border-radius: 18px;
+  background: rgba(248, 245, 239, 0.08);
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.4);
+  margin-bottom: 1.75rem;
+}
+
+.cta-logo img {
+  display: block;
 }
 
 h1,

--- a/app/location/page.tsx
+++ b/app/location/page.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from "next";
+import { BrandLogo } from "@/components/BrandLogo";
 
 export const metadata: Metadata = {
   title: "Service Area & Location",
@@ -22,6 +23,7 @@ export default function LocationPage() {
     <>
       <section className="hero">
         <div className="container">
+          <BrandLogo className="hero-logo" />
           <h1>Rooted in Austin, serving Central Texas.</h1>
           <p>
             Our headquarters is centrally located to reach every corner of the Austin metro.

--- a/app/moving-services/page.tsx
+++ b/app/moving-services/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { Metadata } from "next";
 import { CallToActionBanner } from "@/components/CallToActionBanner";
+import { BrandLogo } from "@/components/BrandLogo";
 
 export const metadata: Metadata = {
   title: "Moving Services in Austin",
@@ -56,6 +57,7 @@ export default function MovingServicesPage() {
     <>
       <section className="hero">
         <div className="container">
+          <BrandLogo className="hero-logo" />
           <h1>Premium moving services crafted for Austin.</h1>
           <p>
             From downtown high-rises to Hill Country estates, Wilson Moving and Property

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,9 +1,11 @@
 import Link from "next/link";
+import { BrandLogo } from "@/components/BrandLogo";
 
 export default function NotFound() {
   return (
     <section className="hero">
       <div className="container" style={{ textAlign: "center" }}>
+        <BrandLogo className="hero-logo" />
         <h1>Page not found</h1>
         <p>The page you&apos;re looking for has moved or no longer exists.</p>
         <Link href="/" className="button" style={{ marginTop: "2rem" }}>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { CallToActionBanner } from "@/components/CallToActionBanner";
+import { BrandLogo } from "@/components/BrandLogo";
 
 const coreServices = [
   {
@@ -35,6 +36,7 @@ export default function HomePage() {
         <div className="container">
           <div className="split">
             <div>
+              <BrandLogo size="lg" className="hero-logo" priority />
               <span className="tag">Austin, Texas</span>
               <h1>Moving in Austin made effortless.</h1>
               <p>

--- a/components/BrandLogo.tsx
+++ b/components/BrandLogo.tsx
@@ -1,0 +1,36 @@
+import Image from "next/image";
+import { HTMLAttributes } from "react";
+
+type BrandLogoProps = {
+  size?: "sm" | "md" | "lg";
+  priority?: boolean;
+  alt?: string;
+} & Omit<HTMLAttributes<HTMLSpanElement>, "children">;
+
+const sizeMap = {
+  sm: 72,
+  md: 104,
+  lg: 144
+} as const;
+
+export function BrandLogo({
+  size = "md",
+  priority,
+  alt = "Wilson Moving & Property Services logo",
+  className,
+  ...rest
+}: BrandLogoProps) {
+  const dimension = sizeMap[size];
+
+  return (
+    <span className={className} {...rest}>
+      <Image
+        src="/logo.svg"
+        alt={alt}
+        width={dimension}
+        height={dimension}
+        priority={priority}
+      />
+    </span>
+  );
+}

--- a/components/CallToActionBanner.tsx
+++ b/components/CallToActionBanner.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { BrandLogo } from "@/components/BrandLogo";
 
 interface CallToActionBannerProps {
   heading: string;
@@ -50,6 +51,7 @@ export function CallToActionBanner({
             border: "1px solid rgba(243, 201, 139, 0.35)"
           }}
         >
+          <BrandLogo className="cta-logo" />
           <h2 style={{ fontSize: "2.25rem", marginBottom: "1rem" }}>{heading}</h2>
           <p style={{ marginBottom: "2rem" }}>{subheading}</p>
           <div

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,9 +1,11 @@
 import Link from "next/link";
+import { BrandLogo } from "@/components/BrandLogo";
 
 export function Footer() {
   return (
     <footer>
       <div className="container" style={{ textAlign: "center" }}>
+        <BrandLogo size="sm" className="footer-logo" />
         <p style={{ marginBottom: "1rem" }}>
           &copy; {new Date().getFullYear()} Wilson Moving and Property Services. All
           rights reserved.

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useState } from "react";
+import { BrandLogo } from "@/components/BrandLogo";
 
 const links = [
   { href: "/", label: "Home" },
@@ -19,8 +20,19 @@ export function Header() {
   return (
     <header className="header">
       <div className="container header-inner">
-        <Link href="/" className="logo">
-          Wilson Moving &amp; Property Services
+        <Link
+          href="/"
+          className="logo"
+          aria-label="Wilson Moving & Property Services home"
+        >
+          <BrandLogo
+            size="sm"
+            className="logo-mark"
+            priority
+            alt=""
+            aria-hidden
+          />
+          <span className="logo-text">Wilson Moving &amp; Property Services</span>
         </Link>
         <button
           type="button"
@@ -36,10 +48,7 @@ export function Header() {
           <ul id={navId} className={isMenuOpen ? "is-open" : undefined}>
             {links.map((link) => (
               <li key={link.href}>
-                <Link
-                  href={link.href}
-                  onClick={() => setMenuOpen(false)}
-                >
+                <Link href={link.href} onClick={() => setMenuOpen(false)}>
                   {link.label}
                 </Link>
               </li>

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <g fill="none" fill-rule="evenodd">
+    <path fill="#040404" d="M0 0h512v512H0z" opacity="0"/>
+    <path fill="#F8F5EF" d="M64 104h92.8l99.2 246.72L355.2 104H448L296.64 408H215.2z"/>
+    <path fill="#F8F5EF" d="M184 104h56l56 150.4L352 104h56L280 408h-48z" opacity="0.4"/>
+    <path fill="#040404" d="M240 216h32c17.673 0 32 14.327 32 32v76h-96v-76c0-17.673 14.327-32 32-32Z"/>
+    <path fill="#F8F5EF" d="M224 256h16v20h-16zm48 0h16v20h-16zm-48 44h64v36h-64z"/>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- add a reusable BrandLogo component backed by a new SVG asset
- update navigation, footer, CTAs, and hero sections to feature the logo and reinforce the brand
- refresh global styling to accommodate logo badges across the layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e589ec07a08331bbef28bd4044a2f1